### PR TITLE
Fix chaining by using correct `this` reference.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ function withoutCustomOptions(options) {
     return omit(options, ['enabled', 'globs', 'extensions']);
 }
 
-mix.purgeCss = function(options = {}) {
+mix.purgeCss = (options = {}) => {
     options = createOptions(options);
 
     if (options.enabled) {
@@ -63,5 +63,5 @@ mix.purgeCss = function(options = {}) {
         });
     }
 
-    return this;
+    return mix;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ function withoutCustomOptions(options) {
     return omit(options, ['enabled', 'globs', 'extensions']);
 }
 
-mix.purgeCss = (options = {}) => {
+mix.purgeCss = function(options = {}) {
     options = createOptions(options);
 
     if (options.enabled) {


### PR DESCRIPTION
Switch from ES2015 fat arrow function syntax to an anonymous function so that `this` refers to the mix object and not an empty object.

I tried v1.0.4 and it still wasn't chainable. I would get an error with this:

`TypeError: mix.options(...).webpackConfig(...).babelConfig(...).sass(...).copyDirectory(...).js(...).autoload(...).extract(...).purgeCss(...).sourceMaps is not a function`

No matter where I put purgeCss in the chain the next function gets the '... is not a function'. It only works if it is the last one in the chain.

The problem was that the `this` being returned was referencing an empty object. This PR fixes that.