### PR TITLE
Bump Purgecss version to allow support for whitelistPatternsChildren option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ mix
 
         // Other options are passed through to Purgecss
         whitelistPatterns: [/language/, /hljs/],
+
+        whitelistPatternsChildren: [/^markdown$/],
     });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-mix-purgecss",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Purgecss wrapper for Laravel Mix",
   "main": "src/index.js",
   "repository": {
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "glob-all": "^3.1.0",
-    "purgecss-webpack-plugin": "^0.19.0"
+    "purgecss-webpack-plugin": "^0.22"
   },
   "devDependencies": {
     "eslint": "^4.19.1",


### PR DESCRIPTION
This PR simply bumps the underlying `purgecss-webpack-plugin` version which brings support for a new `whitelistPatternsChildren` option. 