### PR TITLE
Exclude folders from glob-all

### DIFF
--- a/src/createPurgeCssPlugin.js
+++ b/src/createPurgeCssPlugin.js
@@ -8,11 +8,15 @@ const extractAllSelectorLikeStrings = class {
     }
 };
 
-module.exports = options =>
-    new PurgecssPlugin(
+module.exports = options => {
+    const globs = glob
+        .sync(options.globs, { mark: true })
+        .filter(function(f) { return !/\/$/.test(f); });
+
+    return new PurgecssPlugin(
         Object.assign(
             {
-                paths: () => glob.sync(options.globs),
+                paths: () => globs,
                 extractors: [
                     {
                         extractor: extractAllSelectorLikeStrings,
@@ -23,3 +27,4 @@ module.exports = options =>
             omit(options, ['enabled', 'globs', 'extensions'])
         )
     );
+}


### PR DESCRIPTION
This fixes an error that occurs when a folder ends in one of the configured extensions (more info: #18). In my case I had a folder named ```jump.js```.  When using/running laravel-mix-purgecss I received the following error:

```
/Users/wiljanslofstra/Sites/project_name/node_modules/purgecss/lib/purgecss.js:678
                        throw _iteratorError5;
                        ^

Error: EISDIR: illegal operation on a directory, read
    at Object.fs.readSync (fs.js:675:18)
    at tryReadSync (fs.js:540:20)
    at Object.fs.readFileSync (fs.js:583:19)
    at Purgecss.extractFileSelector (/Users/wiljanslofstra/Sites/project_name/node_modules/purgecss/lib/purgecss.js:649:46)
    at Purgecss.purge (/Users/wiljanslofstra/Sites/project_name/node_modules/purgecss/lib/purgecss.js:409:41)
    at /Users/wiljanslofstra/Sites/project_name/node_modules/purgecss-webpack-plugin/lib/purgecss-webpack-plugin.js:205:97
    at Array.forEach (<anonymous>)
    at /Users/wiljanslofstra/Sites/project_name/node_modules/purgecss-webpack-plugin/lib/purgecss-webpack-plugin.js:155:39
    at Array.forEach (<anonymous>)
...and more
```

To prevent glob-all from matching folders ending in one of the extensions, I've added the option ```mark: true``` that adds slashes to the end of the path if it's a folder. And a filter that removes all paths ending in slashes (folders). This solution is copied from the glob-all documentation: [https://github.com/jpillora/node-glob-all](https://github.com/jpillora/node-glob-all)