### PR TITLE
Add twig files to default config

### DIFF
--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -9,7 +9,8 @@ module.exports = {
         rootPath('resources/**/*.ts'),
         rootPath('resources/**/*.tsx'),
         rootPath('resources/**/*.php'),
-        rootPath('resources/**/*.vue')
+        rootPath('resources/**/*.vue'),
+        rootPath('resources/**/*.twig')
     ],
     defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
     whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/]


### PR DESCRIPTION
This PR adds twig as a valid filetype for PurgeCSS to check. We mainly use Twig internally for our Laravel projects.

We're aware of the ability to overrule the config, but this would make it just a bit easier to use :)