### PR TITLE
Expand the default extractor pattern

### DIFF
--- a/__test__/__snapshots__/integration.test.js.snap
+++ b/__test__/__snapshots__/integration.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`it purges css 1`] = `".bg-blue{background-color:#00f}.is-active{background-color:green}"`;
+exports[`it purges css 1`] = `".bg-blue{background-color:#00f}.is-active{background-color:green}.p-2\\\\.5{padding:2.5rem}"`;

--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -11,6 +11,6 @@ module.exports = {
         rootPath('resources/**/*.php'),
         rootPath('resources/**/*.vue')
     ],
-    defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
+    defaultExtractor: content => content.match(/[\w-/.:]+(?<!:)/g) || [],
     whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/]
 };

--- a/example/resources/css/app.css
+++ b/example/resources/css/app.css
@@ -9,3 +9,7 @@
 .is-active {
     background-color: green;
 }
+
+.p-2\.5 {
+    padding: 2.5rem;
+}

--- a/example/resources/views/welcome.blade.php
+++ b/example/resources/views/welcome.blade.php
@@ -1,3 +1,5 @@
 <div class="bg-blue">
-    Welcome!
+    <div class="p-2.5">
+        Welcome!
+    </div>
 </div>


### PR DESCRIPTION
This PR moves the default extractor pattern to the default one of Tailwind UI.

The pattern would include the same items as before, but adds support by default for classes with 'dots' in the name as well. For instance `p-2.5` which is a default class provided by Tailwind UI.

Reference: https://tailwindui.com/documentation#update-your-purgecss-configuration