### PR TITLE
Laravel Mix 6 support

### DIFF
--- a/__test__/__snapshots__/integration.test.js.snap
+++ b/__test__/__snapshots__/integration.test.js.snap
@@ -1,3 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`it purges css 1`] = `".bg-blue{background-color:#00f}.is-active{background-color:green}.p-2\\\\.5{padding:2.5rem}"`;
+exports[`it purges css 1`] = `
+".bg-blue{background-color:#00f}.is-active{background-color:green}.p-2\\\\.5{padding:2.5rem}
+"
+`;

--- a/example/package.json
+++ b/example/package.json
@@ -7,9 +7,7 @@
         "cross-env": "^7.0.0",
         "laravel-mix": "^6.0.0-beta",
         "laravel-mix-purgecss": "file:..",
+        "postcss": "^8.1.2",
         "postcss-loader": "^4.0.4"
-    },
-    "resolutions": {
-        "postcss": "8.1.2"
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "cross-env": "^7.0.0",
-        "laravel-mix": "^6.0.0-beta",
+        "laravel-mix": "^6.0.0",
         "laravel-mix-purgecss": "file:..",
         "postcss": "^8.1.2"
     }

--- a/example/package.json
+++ b/example/package.json
@@ -1,11 +1,11 @@
 {
     "private": true,
     "scripts": {
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "dependencies": {
         "cross-env": "^7.0.0",
-        "laravel-mix": "^5.0.1",
+        "laravel-mix": "^6.0.0-beta",
         "laravel-mix-purgecss": "file:.."
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,6 @@
         "cross-env": "^7.0.0",
         "laravel-mix": "^6.0.0-beta",
         "laravel-mix-purgecss": "file:..",
-        "postcss": "^8.1.2",
-        "postcss-loader": "^4.0.4"
+        "postcss": "^8.1.2"
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -6,6 +6,10 @@
     "dependencies": {
         "cross-env": "^7.0.0",
         "laravel-mix": "^6.0.0-beta",
-        "laravel-mix-purgecss": "file:.."
+        "laravel-mix-purgecss": "file:..",
+        "postcss-loader": "^4.0.4"
+    },
+    "resolutions": {
+        "postcss": "8.1.2"
     }
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ mix.extend(
 
             mix.options({
                 postCss: [
-                    ...mix.config.postCss,
+                    ...global.Config.postCss,
                     require("postcss-purgecss-laravel")(this.config),
                 ],
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laravel-mix-purgecss",
-    "version": "6.0.0-beta.0",
+    "version": "6.0.0",
     "description": "PurgeCSS wrapper for Laravel Mix",
     "main": "index.js",
     "repository": {
@@ -32,7 +32,7 @@
         "prettier": "^2.0.5"
     },
     "peerDependencies": {
-        "laravel-mix": "^6.0.0-beta"
+        "laravel-mix": "^6.0.0"
     },
     "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laravel-mix-purgecss",
-    "version": "6.0.0",
+    "version": "6.0.0-beta.0",
     "description": "PurgeCSS wrapper for Laravel Mix",
     "main": "index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "prettier": "^2.0.5"
     },
     "peerDependencies": {
-        "laravel-mix": "^5.0.1|^6.0.0-beta"
+        "laravel-mix": "^6.0.0-beta"
     },
     "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laravel-mix-purgecss",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "description": "PurgeCSS wrapper for Laravel Mix",
     "main": "index.js",
     "repository": {
@@ -25,14 +25,14 @@
         "build-example": "./build-example.sh"
     },
     "dependencies": {
-        "postcss-purgecss-laravel": "^0.1.1"
+        "postcss-purgecss-laravel": "^2.0.0"
     },
     "devDependencies": {
         "jest": "^25.4.0",
         "prettier": "^2.0.5"
     },
     "peerDependencies": {
-        "laravel-mix": "^5.0.1"
+        "laravel-mix": "^5.0.1|^6.0.0-beta"
     },
     "engines": {
         "node": ">=12.0.0"


### PR DESCRIPTION
This branch correctly compiles the test stylesheet, but there are a few more (I believe upstream) issues that need to be resolved before this is stable.

- Webpack throws an error that `postcss-loader` is missing, despite it being installed and available in `node_modules`. Adding `postcss-loader` as an explicit dependency solves the issue
- Some plugins require Postcss 7, others 8. These are generally compatible with each other, so it's just the upstream packages that need to change their required Postcss versions to 8. This can be solved if you're using yarn by adding a `resolutions` entry in your `package.json`.

Once the stylesheets builds without these workarounds, this can be merged. Either way, I'm waiting on a stable Laravel Mix 6 release to tag this one.