### PR TITLE
Updating readme according to PostCSS 3 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ mix.js('resources/js/app.js', 'public/js')
    .sass('resources/sass/app.scss', 'public/css')
    .purgeCss({
        content: [path.join(__dirname, 'vendor/spatie/menu/**/*.php')],
-       whitelistPatterns: [/hljs/],
+       safelist: [/hljs/],
    });
 ```
 
@@ -124,7 +124,7 @@ mix.js('resources/js/app.js', 'public/js')
    .purgeCss({
        extend: {
            content: [path.join(__dirname, 'vendor/spatie/menu/**/*.php')],
-           whitelistPatterns: [/hljs/],
+           safelist: [/hljs/],
        },
    });
 ```
@@ -145,7 +145,7 @@ const defaultConfig = {
         "resources/**/*.twig",
     ],
     defaultExtractor: (content) => content.match(/[\w-/.:]+(?<!:)/g) || [],
-    whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
+    safelist: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
 }
 ```
 


### PR DESCRIPTION
After PostCSS 3, which is currently used by version 6 of the package, we need to use `safelist` instead of `whitelistPatterns`
This will save some time for other developers.